### PR TITLE
Add support for destructured records

### DIFF
--- a/ClosedTypeHierarchyDiagnosticSuppressor.Tests/SwitchExpressionSuppressorTests.cs
+++ b/ClosedTypeHierarchyDiagnosticSuppressor.Tests/SwitchExpressionSuppressorTests.cs
@@ -20,9 +20,9 @@ class SwitchExpressionSuppressorTests
             nullableContextOptions,
             ("IDE0072", IDE0072Analyzer));
 
-    Task EnsureSuppressed(string code, NullableContextOptions nullableContextOptions) =>
+    Task EnsureSuppressed(string code, NullableContextOptions nullableContextOptions, bool allowRecords = false) =>
         DiagnosticSuppressorAnalyer.EnsureSuppressed(
-            new SwitchExpressionSuppressor(),
+            new SwitchExpressionSuppressor(allowRecords),
             SwitchExpressionSuppressor.SuppressionDescriptorByDiagnosticId.Values,
             code,
             nullableContextOptions,
@@ -86,6 +86,26 @@ static class SwitchTest
 ");
 
         return EnsureNotSuppressed(code, NullableContextOptions.Disable);
+    }
+    
+    [Test]
+    public Task When_record_with_destructure_And_all_subtypes_match_Then_suppress()
+    {
+        var code = CodeHelper.WrapInNamespace(TypeHierarchies.ProtectedCopyConstructorOnly.PositionalParameter + @"
+static class SwitchTest
+{
+    public static int DoSwitch(Root root)
+    {
+        return root switch
+        {
+            Root.Leaf1(var v) => 0,
+            Root.Leaf2 => 1,
+        };
+    }
+}
+");
+
+        return EnsureSuppressed(code, NullableContextOptions.Enable, allowRecords: true);
     }
 
     [Test]

--- a/ClosedTypeHierarchyDiagnosticSuppressor.Tests/SwitchExpressionSuppressorTests.cs
+++ b/ClosedTypeHierarchyDiagnosticSuppressor.Tests/SwitchExpressionSuppressorTests.cs
@@ -13,9 +13,9 @@ class SwitchExpressionSuppressorTests
         "Microsoft.CodeAnalysis.CSharp.PopulateSwitch.CSharpPopulateSwitchExpressionDiagnosticAnalyzer")?.Unwrap()
         ?? throw new InvalidOperationException("could not instantiate populate switch expression analyzer for IDE0072"));
 
-    Task EnsureNotSuppressed(string code, NullableContextOptions nullableContextOptions) =>
+    Task EnsureNotSuppressed(string code, NullableContextOptions nullableContextOptions, bool allowRecords = false) =>
         DiagnosticSuppressorAnalyer.EnsureNotSuppressed(
-            new SwitchExpressionSuppressor(),
+            new SwitchExpressionSuppressor(allowRecords),
             code,
             nullableContextOptions,
             ("IDE0072", IDE0072Analyzer));
@@ -106,6 +106,26 @@ static class SwitchTest
 ");
 
         return EnsureSuppressed(code, NullableContextOptions.Enable, allowRecords: true);
+    }
+    
+    [Test]
+    public Task When_record_with_destructure_And_only_base_type_is_matched_Then_do_not_suppress()
+    {
+        var code = CodeHelper.WrapInNamespace(TypeHierarchies.ProtectedCopyConstructorOnly.PositionalParameter + @"
+static class SwitchTest
+{
+    public static int DoSwitch(Root root)
+    {
+        return root switch
+        {
+            Root.Leaf1(object v) => 0,
+            Root.Leaf2 => 1,
+        };
+    }
+}
+");
+
+        return EnsureNotSuppressed(code, NullableContextOptions.Enable, allowRecords: true);
     }
 
     [Test]

--- a/ClosedTypeHierarchyDiagnosticSuppressor.Tests/SwitchStatementSuppressorTests.cs
+++ b/ClosedTypeHierarchyDiagnosticSuppressor.Tests/SwitchStatementSuppressorTests.cs
@@ -13,9 +13,9 @@ class SwitchStatementSuppressorTests
         "Microsoft.CodeAnalysis.CSharp.PopulateSwitch.CSharpPopulateSwitchStatementDiagnosticAnalyzer")?.Unwrap()
         ?? throw new InvalidOperationException("could not instantiate populate switch statement analyzer for IDE0072"));
 
-    Task EnsureNotSuppressed(string code, NullableContextOptions nullableContextOptions) =>
+    Task EnsureNotSuppressed(string code, NullableContextOptions nullableContextOptions, bool allowRecords = false) =>
         DiagnosticSuppressorAnalyer.EnsureNotSuppressed(
-            new SwitchStatementSuppressor(),
+            new SwitchStatementSuppressor(allowRecords),
             code,
             nullableContextOptions,
             ("IDE0010", IDE0010Analyzer));
@@ -114,6 +114,28 @@ static class SwitchTest
 ");
 
         return EnsureSuppressed(code, NullableContextOptions.Enable, allowRecords: true);
+    }
+    
+    [Test]
+    public Task When_record_with_destructure_And_only_base_type_is_matched_Then_do_not_suppress()
+    {
+        var code = CodeHelper.WrapInNamespace(TypeHierarchies.ProtectedCopyConstructorOnly.PositionalParameter + @"
+static class SwitchTest
+{
+    public static void DoSwitch(Root root)
+    {
+        switch(root)
+        {
+            case Root.Leaf1(object v):
+                break;
+            case Root.Leaf2:
+                break;
+        };
+    }
+}
+");
+
+        return EnsureNotSuppressed(code, NullableContextOptions.Enable, allowRecords: true);
     }
     
     [Test]

--- a/ClosedTypeHierarchyDiagnosticSuppressor.Tests/SwitchStatementSuppressorTests.cs
+++ b/ClosedTypeHierarchyDiagnosticSuppressor.Tests/SwitchStatementSuppressorTests.cs
@@ -20,9 +20,9 @@ class SwitchStatementSuppressorTests
             nullableContextOptions,
             ("IDE0010", IDE0010Analyzer));
 
-    Task EnsureSuppressed(string code, NullableContextOptions nullableContextOptions) =>
+    Task EnsureSuppressed(string code, NullableContextOptions nullableContextOptions, bool allowRecords = false) =>
         DiagnosticSuppressorAnalyer.EnsureSuppressed(
-            new SwitchStatementSuppressor(),
+            new SwitchStatementSuppressor(allowRecords),
             SwitchStatementSuppressor.SuppressionDescriptorByDiagnosticId.Values,
             code,
             nullableContextOptions,
@@ -94,6 +94,28 @@ static class SwitchTest
         return EnsureNotSuppressed(code, NullableContextOptions.Disable);
     }
 
+    [Test]
+    public Task When_record_with_destructure_And_all_subtypes_match_Then_suppress()
+    {
+        var code = CodeHelper.WrapInNamespace(TypeHierarchies.ProtectedCopyConstructorOnly.PositionalParameter + @"
+static class SwitchTest
+{
+    public static void DoSwitch(Root root)
+    {
+        switch(root)
+        {
+            case Root.Leaf1(var v):
+                break;
+            case Root.Leaf2:
+                break;
+        }
+    }
+}
+");
+
+        return EnsureSuppressed(code, NullableContextOptions.Enable, allowRecords: true);
+    }
+    
     [Test]
     public Task When_nullable_is_disabled_And_null_is_matched_on_its_own_Then_suppress()
     {

--- a/ClosedTypeHierarchyDiagnosticSuppressor.Tests/TypeHierarchies.cs
+++ b/ClosedTypeHierarchyDiagnosticSuppressor.Tests/TypeHierarchies.cs
@@ -54,7 +54,7 @@ abstract record Root
 abstract record Root
 {
     Root() {}
-    public sealed record Leaf1(int Value) : Root {}
+    public sealed record Leaf1(string Value) : Root {}
     public sealed record Leaf2 : Root {}
 }
 ";

--- a/ClosedTypeHierarchyDiagnosticSuppressor.Tests/TypeHierarchies.cs
+++ b/ClosedTypeHierarchyDiagnosticSuppressor.Tests/TypeHierarchies.cs
@@ -50,6 +50,14 @@ abstract record Root
     public sealed record Leaf2 : Root {}
 }
 ";
+        public const string PositionalParameter = @"
+abstract record Root
+{
+    Root() {}
+    public sealed record Leaf1(int Value) : Root {}
+    public sealed record Leaf2 : Root {}
+}
+";
     }
 
     public static class NotClosed

--- a/ClosedTypeHierarchyDiagnosticSuppressor/ClosedTypeHierarchyDiagnosticSuppressor.csproj
+++ b/ClosedTypeHierarchyDiagnosticSuppressor/ClosedTypeHierarchyDiagnosticSuppressor.csproj
@@ -19,6 +19,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="ClosedTypeHierarchyDiagnosticSuppressor.Tests" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 

--- a/ClosedTypeHierarchyDiagnosticSuppressor/PatternHelper.cs
+++ b/ClosedTypeHierarchyDiagnosticSuppressor/PatternHelper.cs
@@ -51,7 +51,8 @@ static class PatternHelper
             };
 
         bool IsRecursivePatternNonRestrictive(RecursivePatternSyntax recursivePatternSyntax) =>
-            recursivePatternSyntax.PropertyPatternClause?.Subpatterns.All(IsSubpatternNonRestrictive) ?? false;
+            (recursivePatternSyntax.PropertyPatternClause?.Subpatterns ?? recursivePatternSyntax.PositionalPatternClause?.Subpatterns)
+            ?.All(IsSubpatternNonRestrictive) ?? false;
 
         bool IsDeclarationPatternNonRestrictive(DeclarationPatternSyntax declarationPatternSyntax, SubpatternSyntax containingSubpatternSyntax)
         {

--- a/ClosedTypeHierarchyDiagnosticSuppressor/SwitchExpressionSuppressor.cs
+++ b/ClosedTypeHierarchyDiagnosticSuppressor/SwitchExpressionSuppressor.cs
@@ -17,7 +17,8 @@ public sealed class SwitchExpressionSuppressor : DiagnosticSuppressor
 
     public SwitchExpressionSuppressor() : this(false) { }
     
-    public SwitchExpressionSuppressor(bool forceAllowRecords)
+    /// <summary>Constructor to facilitate unit testing</summary>
+    internal SwitchExpressionSuppressor(bool forceAllowRecords)
     {
         _forceAllowRecords = forceAllowRecords;
     }

--- a/ClosedTypeHierarchyDiagnosticSuppressor/SwitchExpressionSuppressor.cs
+++ b/ClosedTypeHierarchyDiagnosticSuppressor/SwitchExpressionSuppressor.cs
@@ -13,6 +13,15 @@ namespace SvSoft.Analyzers.ClosedTypeHerarchyDiagnosticSuppression;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class SwitchExpressionSuppressor : DiagnosticSuppressor
 {
+    readonly bool _forceAllowRecords;
+
+    public SwitchExpressionSuppressor() : this(false) { }
+    
+    public SwitchExpressionSuppressor(bool forceAllowRecords)
+    {
+        _forceAllowRecords = forceAllowRecords;
+    }
+    
     static readonly string[] SuppressedDiagnosticIds = { "CS8509", "IDE0072" };
 
     public static readonly IReadOnlyDictionary<string, SuppressionDescriptor> SuppressionDescriptorByDiagnosticId = SuppressedDiagnosticIds.ToDictionary(
@@ -42,7 +51,7 @@ public sealed class SwitchExpressionSuppressor : DiagnosticSuppressor
                 return;
             }
 
-            bool allowRecords = context.AreRecordHierarchiesAllowed(node.SyntaxTree);
+            bool allowRecords = _forceAllowRecords || context.AreRecordHierarchiesAllowed(node.SyntaxTree);
 
             var switchExpression = node.DescendantNodesAndSelf().OfType<SwitchExpressionSyntax>().FirstOrDefault();
 

--- a/ClosedTypeHierarchyDiagnosticSuppressor/SwitchStatementSuppressor.cs
+++ b/ClosedTypeHierarchyDiagnosticSuppressor/SwitchStatementSuppressor.cs
@@ -16,7 +16,8 @@ public sealed class SwitchStatementSuppressor : DiagnosticSuppressor
 
     public SwitchStatementSuppressor() : this(false) { }
     
-    public SwitchStatementSuppressor(bool forceAllowRecords)
+    /// <summary>Constructor to facilitate unit testing</summary>
+    internal SwitchStatementSuppressor(bool forceAllowRecords)
     {
         _forceAllowRecords = forceAllowRecords;
     }

--- a/ClosedTypeHierarchyDiagnosticSuppressor/SwitchStatementSuppressor.cs
+++ b/ClosedTypeHierarchyDiagnosticSuppressor/SwitchStatementSuppressor.cs
@@ -12,6 +12,15 @@ namespace SvSoft.Analyzers.ClosedTypeHerarchyDiagnosticSuppression;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public sealed class SwitchStatementSuppressor : DiagnosticSuppressor
 {
+    readonly bool _forceAllowRecords;
+
+    public SwitchStatementSuppressor() : this(false) { }
+    
+    public SwitchStatementSuppressor(bool forceAllowRecords)
+    {
+        _forceAllowRecords = forceAllowRecords;
+    }
+    
     static readonly string[] SuppressedDiagnosticIds = { "IDE0010" };
 
     public static readonly IReadOnlyDictionary<string, SuppressionDescriptor> SuppressionDescriptorByDiagnosticId = SuppressedDiagnosticIds.ToDictionary(
@@ -40,7 +49,7 @@ public sealed class SwitchStatementSuppressor : DiagnosticSuppressor
                     return;
                 }
 
-                bool allowRecords = context.AreRecordHierarchiesAllowed(node.SyntaxTree);
+                bool allowRecords = _forceAllowRecords || context.AreRecordHierarchiesAllowed(node.SyntaxTree);
 
                 ExpressionSyntax switchee = switchStatement.Expression;
                 var switcheeModel = context.GetSemanticModel(switchee.SyntaxTree);


### PR DESCRIPTION
This PR adds support for patterns that destructure a record with positional params.

```csharp
abstract record Root
{
    Root() {}
    public sealed record Leaf1(int Value) : Root {}
    public sealed record Leaf2 : Root {}
}


return root switch
{
    Root.Leaf1(var v) => 0,
    Root.Leaf2 => 1,
};
```

I wasn't sure how to create a unit test with a specific editor config so I added a new constructor param to the suppressors. Let me know if that's no good.